### PR TITLE
Config driven HTTP status for missing token and other changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Use the following maven dependency:
 <dependency>
     <groupId>io.dropwizard.primer</groupId>
     <artifactId>primer-bundle</artifactId>
-    <version>1.3.7-6</version>
+    <version>1.3.7-7</version>
 </dependency>
 ```
 
@@ -66,6 +66,9 @@ Use the following maven dependency:
 ```yaml
 primer:
   enabled: true
+  authTypesEnabled:
+    CONFIG: true
+    ANNOTATION: true
   endpoint:
     type: simple
     host: my.primer.somewhere

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Use the following maven dependency:
 <dependency>
     <groupId>io.dropwizard.primer</groupId>
     <artifactId>primer-bundle</artifactId>
-    <version>1.3.7-7</version>
+    <version>1.3.7-8</version>
 </dependency>
 ```
 
@@ -69,6 +69,7 @@ primer:
   authTypesEnabled:
     CONFIG: true
     ANNOTATION: true
+  absentTokenStatus: BAD_REQUEST
   endpoint:
     type: simple
     host: my.primer.somewhere

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>io.dropwizard</groupId>
     <artifactId>dropwizard-primer</artifactId>
-    <version>1.3.7-8-SNAPSHOT</version>
+    <version>1.3.7-8-rc-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>dropwizard-primer</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>io.dropwizard</groupId>
     <artifactId>dropwizard-primer</artifactId>
-    <version>1.3.7-8-rc-SNAPSHOT</version>
+    <version>1.3.7-8</version>
     <packaging>jar</packaging>
 
     <name>dropwizard-primer</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>io.dropwizard</groupId>
     <artifactId>dropwizard-primer</artifactId>
-    <version>1.3.7-7</version>
+    <version>1.3.7-8-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>dropwizard-primer</name>

--- a/src/main/java/io/dropwizard/primer/auth/AuthFilter.java
+++ b/src/main/java/io/dropwizard/primer/auth/AuthFilter.java
@@ -101,12 +101,12 @@ public abstract class AuthFilter implements ContainerRequestFilter {
             );
         } else if (e.getCause() instanceof FeignException) {
             log.error("Feign error: {}", e.getMessage());
-            handleError(Response.Status.fromStatusCode(((FeignException) e.getCause()).status()), "PR000", e.getCause().getMessage(), token,
+            handleError(Response.Status.fromStatusCode(((FeignException) e.getCause()).status()), "PR000", e.getCause().getMessage(), token, false,
                     requestContext);
 
         } else if (e instanceof FeignException) {
             log.error("Feign error: {}", e.getMessage());
-            handleError(Response.Status.fromStatusCode(((FeignException) e).status()), "PR000", e.getMessage(), token,
+            handleError(Response.Status.fromStatusCode(((FeignException) e).status()), "PR000", e.getMessage(), token, false,
                     requestContext);
         } else if (e.getCause() instanceof PrimerException) {
             PrimerException primerException = (PrimerException) e.getCause();
@@ -117,7 +117,7 @@ public abstract class AuthFilter implements ContainerRequestFilter {
                     primerException.getMessage(),
                     requestContext.getHeaders());
             handleError(Response.Status.fromStatusCode(((PrimerException) e.getCause()).getStatus()), ((PrimerException) e.getCause()).getErrorCode(),
-                    e.getCause().getMessage(), token, requestContext);
+                    e.getCause().getMessage(), token, ((PrimerException) e.getCause()).isRecoverable(), requestContext);
         } else if (e instanceof PrimerException) {
             PrimerException primerException = (PrimerException) e;
             log.error("Primer error: {}", e.getMessage());
@@ -127,23 +127,25 @@ public abstract class AuthFilter implements ContainerRequestFilter {
                     primerException.getMessage(),
                     requestContext.getHeaders());
             handleError(Response.Status.fromStatusCode(((PrimerException) e).getStatus()), ((PrimerException) e).getErrorCode(),
-                    e.getMessage(), token, requestContext);
+                    e.getMessage(), token, ((PrimerException) e).isRecoverable(), requestContext);
         } else {
             log.error("General error: ", e);
-            handleError(Response.Status.INTERNAL_SERVER_ERROR, "PR000", "Error", token, requestContext);
+            handleError(Response.Status.INTERNAL_SERVER_ERROR, "PR000", "Error", token, false, requestContext);
         }
     }
 
-    protected void handleError(Response.Status status, String errorCode, String message, String token,
+    protected void handleError(Response.Status status, String errorCode, String message, String token, boolean recoverable,
                              ContainerRequestContext requestContext) throws JsonProcessingException {
         switch (status) {
             case NOT_FOUND:
             case UNAUTHORIZED:
-                PrimerAuthorizationRegistry.blacklist(token);
+                if (!recoverable)
+                    PrimerAuthorizationRegistry.blacklist(token);
                 abortRequest(requestContext, Response.Status.UNAUTHORIZED, PrimerError.builder().errorCode("PR004").message("Unauthorized").build());
                 break;
             case FORBIDDEN:
-                PrimerAuthorizationRegistry.blacklist(token);
+                if (!recoverable)
+                    PrimerAuthorizationRegistry.blacklist(token);
                 abortRequest(requestContext, Response.Status.FORBIDDEN, PrimerError.builder().errorCode("PR002").message("Forbidden").build());
                 break;
             default:

--- a/src/main/java/io/dropwizard/primer/auth/annotation/Authorize.java
+++ b/src/main/java/io/dropwizard/primer/auth/annotation/Authorize.java
@@ -1,5 +1,6 @@
 package io.dropwizard.primer.auth.annotation;
 
+import javax.ws.rs.NameBinding;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -7,6 +8,7 @@ import java.lang.annotation.Target;
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.TYPE;
 
+@NameBinding
 @Retention(RetentionPolicy.RUNTIME)
 @Target({TYPE, METHOD})
 public @interface Authorize {

--- a/src/main/java/io/dropwizard/primer/auth/authorizer/PrimerAnnotationAuthorizer.java
+++ b/src/main/java/io/dropwizard/primer/auth/authorizer/PrimerAnnotationAuthorizer.java
@@ -8,5 +8,5 @@ import javax.ws.rs.container.ContainerRequestContext;
 
 public interface PrimerAnnotationAuthorizer {
 
-    boolean authorize(JsonWebToken jwt, ContainerRequestContext containerRequestContext, Authorize authorize) throws PrimerException;
+    void authorize(JsonWebToken jwt, ContainerRequestContext containerRequestContext, Authorize authorize) throws PrimerException;
 }

--- a/src/main/java/io/dropwizard/primer/auth/authorizer/PrimerAnnotationAuthorizer.java
+++ b/src/main/java/io/dropwizard/primer/auth/authorizer/PrimerAnnotationAuthorizer.java
@@ -2,10 +2,11 @@ package io.dropwizard.primer.auth.authorizer;
 
 import com.github.toastshaman.dropwizard.auth.jwt.model.JsonWebToken;
 import io.dropwizard.primer.auth.annotation.Authorize;
+import io.dropwizard.primer.exception.PrimerException;
 
 import javax.ws.rs.container.ContainerRequestContext;
 
 public interface PrimerAnnotationAuthorizer {
 
-    boolean authorize(JsonWebToken jwt, ContainerRequestContext containerRequestContext, Authorize authorize);
+    boolean authorize(JsonWebToken jwt, ContainerRequestContext containerRequestContext, Authorize authorize) throws PrimerException;
 }

--- a/src/main/java/io/dropwizard/primer/auth/authorizer/PrimerRoleAuthorizer.java
+++ b/src/main/java/io/dropwizard/primer/auth/authorizer/PrimerRoleAuthorizer.java
@@ -2,6 +2,7 @@ package io.dropwizard.primer.auth.authorizer;
 
 import com.github.toastshaman.dropwizard.auth.jwt.model.JsonWebToken;
 import io.dropwizard.primer.auth.annotation.Authorize;
+import io.dropwizard.primer.exception.PrimerException;
 import lombok.Builder;
 import lombok.extern.slf4j.Slf4j;
 
@@ -12,20 +13,32 @@ import java.util.List;
 
 /**
  * Created by pavan.kumar on 2019-02-20
+ *
+ * Example authorizer class for role based authorization.
+ * Annotation Usage: @Authorize(value = {"roleName"})
+ *
  */
 @Slf4j
 @Builder
 public class PrimerRoleAuthorizer implements PrimerAnnotationAuthorizer {
 
     @Override
-    public boolean authorize(JsonWebToken jwt, ContainerRequestContext containerRequestContext, Authorize authorize) {
+    public void authorize(JsonWebToken jwt, ContainerRequestContext containerRequestContext, Authorize authorize) throws PrimerException {
 
         List<String> authorizedRoles = Arrays.asList(authorize.value());
 
         if (authorizedRoles.contains(jwt.claim().getParameter("role")))
-            return true;
+            return;
 
-        return jwt.claim().getParameter("roles") != null &&
-                !Collections.disjoint(authorizedRoles, (List) jwt.claim().getParameter("roles"));
+        if(jwt.claim().getParameter("roles") != null &&
+                !Collections.disjoint(authorizedRoles, (List) jwt.claim().getParameter("roles")))
+            return;
+
+        throw PrimerException.builder()
+                .status(401)
+                .errorCode("PR004")
+                .message("Unauthorized")
+                .recoverable(true)
+                .build();
     }
 }

--- a/src/main/java/io/dropwizard/primer/auth/filter/PrimerAuthAnnotationFilter.java
+++ b/src/main/java/io/dropwizard/primer/auth/filter/PrimerAuthAnnotationFilter.java
@@ -22,7 +22,6 @@ import javax.ws.rs.ext.Provider;
 import java.io.IOException;
 import java.util.Optional;
 import java.util.concurrent.CompletionException;
-import java.util.concurrent.ExecutionException;
 
 /**
  * Created by pavan.kumar on 2019-02-19
@@ -62,11 +61,8 @@ public class PrimerAuthAnnotationFilter extends AuthFilter {
                 JsonWebToken webToken = authorize(requestContext, token.get(), this.authType);
 
                 // Execute authorizer
-                if (authorizer != null && !authorizer.authorize(webToken, requestContext, authorize)) {
-                    // Abort request without blacklisting the token. FIXME: This should be controlled by the authorizer.
-                    abortRequest(requestContext, Response.Status.FORBIDDEN, PrimerError.builder().errorCode("PR002").message("Forbidden").build());
-                    return;
-                }
+                if (authorizer != null)
+                    authorizer.authorize(webToken, requestContext, authorize);
 
                 //Stamp authorization headers for downstream services which can
                 // use this to stop token forgery & misuse

--- a/src/main/java/io/dropwizard/primer/auth/filter/PrimerAuthAnnotationFilter.java
+++ b/src/main/java/io/dropwizard/primer/auth/filter/PrimerAuthAnnotationFilter.java
@@ -63,15 +63,8 @@ public class PrimerAuthAnnotationFilter extends AuthFilter {
 
                 // Execute authorizer
                 if (authorizer != null && !authorizer.authorize(webToken, requestContext, authorize)) {
-                    handleException(
-                            PrimerException.builder()
-                                    .errorCode("PR004")
-                                    .message("Unauthorized")
-                                    .status(401)
-                                    .build(),
-                            requestContext,
-                            token.get()
-                    );
+                    // Abort request without blacklisting the token. FIXME: This should be controlled by the authorizer.
+                    abortRequest(requestContext, Response.Status.FORBIDDEN, PrimerError.builder().errorCode("PR002").message("Forbidden").build());
                     return;
                 }
 

--- a/src/main/java/io/dropwizard/primer/auth/filter/PrimerAuthAnnotationFilter.java
+++ b/src/main/java/io/dropwizard/primer/auth/filter/PrimerAuthAnnotationFilter.java
@@ -53,7 +53,7 @@ public class PrimerAuthAnnotationFilter extends AuthFilter {
         Optional<String> token = getToken(requestContext);
         if (!token.isPresent()) {
             requestContext.abortWith(
-                    Response.status(Response.Status.BAD_REQUEST)
+                    Response.status(configuration.getAbsentTokenStatus())
                             .entity(objectMapper.writeValueAsBytes(PrimerError.builder().errorCode("PR000").message("Bad request")
                                     .build())).build()
             );

--- a/src/main/java/io/dropwizard/primer/auth/filter/PrimerAuthConfigFilter.java
+++ b/src/main/java/io/dropwizard/primer/auth/filter/PrimerAuthConfigFilter.java
@@ -68,7 +68,7 @@ public class PrimerAuthConfigFilter extends AuthFilter {
         Optional<String> token = getToken(requestContext);
         if (!token.isPresent()) {
             requestContext.abortWith(
-                    Response.status(Response.Status.BAD_REQUEST)
+                    Response.status(configuration.getAbsentTokenStatus())
                             .entity(objectMapper.writeValueAsBytes(PrimerError.builder().errorCode("PR000").message("Bad request")
                                     .build())).build()
             );

--- a/src/main/java/io/dropwizard/primer/exception/PrimerException.java
+++ b/src/main/java/io/dropwizard/primer/exception/PrimerException.java
@@ -35,4 +35,6 @@ public class PrimerException extends Exception {
     private String errorCode;
 
     private String message;
+
+    private boolean recoverable;
 }

--- a/src/main/java/io/dropwizard/primer/model/PrimerBundleConfiguration.java
+++ b/src/main/java/io/dropwizard/primer/model/PrimerBundleConfiguration.java
@@ -5,6 +5,7 @@ import io.dropwizard.primer.auth.AuthType;
 import lombok.*;
 
 import javax.validation.Valid;
+import javax.ws.rs.core.Response;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -34,6 +35,8 @@ public class PrimerBundleConfiguration {
     private boolean enabled = true;
 
     private Map<AuthType, Boolean> authTypesEnabled = ImmutableMap.of(AuthType.CONFIG, true, AuthType.ANNOTATION, false);
+
+    private Response.Status absentTokenStatus = Response.Status.BAD_REQUEST;
 
     @Singular("whiteList")
     private Set<String> whileListUrl = new HashSet<>();

--- a/src/main/java/io/dropwizard/primer/model/PrimerBundleConfiguration.java
+++ b/src/main/java/io/dropwizard/primer/model/PrimerBundleConfiguration.java
@@ -36,6 +36,7 @@ public class PrimerBundleConfiguration {
 
     private Map<AuthType, Boolean> authTypesEnabled = ImmutableMap.of(AuthType.CONFIG, true, AuthType.ANNOTATION, false);
 
+    @Builder.Default
     private Response.Status absentTokenStatus = Response.Status.BAD_REQUEST;
 
     @Singular("whiteList")


### PR DESCRIPTION
- Refactored the abort request into a separate method
- Added @NameBinding to @Authorize annotation to support jersey filter binding to annotated API
- Support for config driven HTTP status for requests where token is absent
- Support for Annotation authorizer to throw PrimerException for custom error handling and recoverable PrimerException without blacklisting the token.
- Updated README with latest config