### PR TITLE
Add support for root Path Prefix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>io.raven.dropwizard</groupId>
     <artifactId>dropwizard-primer</artifactId>
-    <version>2.0.17</version>
+    <version>2.0.18</version>
     <packaging>jar</packaging>
 
     <name>dropwizard-primer</name>
@@ -49,7 +49,7 @@
         <lombok.maven.version>1.18.16.0</lombok.maven.version>
         <jose4j.version>0.7.7</jose4j.version>
         <feign.version>11.0</feign.version>
-        <feign.ranger.version>0.1.6</feign.ranger.version>
+        <feign.ranger.version>0.1.8</feign.ranger.version>
         <caffeine.version>2.8.8</caffeine.version>
         <slf4j.version>1.7.30</slf4j.version>
         <junit.version>5.7.0</junit.version>
@@ -57,6 +57,7 @@
         <mockito.version>2.13.0</mockito.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <curator.version>3.1.0</curator.version>
     </properties>
 
     <repositories>
@@ -137,6 +138,12 @@
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-testing</artifactId>
             <version>${dropwizard.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-test</artifactId>
+            <version>${curator.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/io/dropwizard/primer/PrimerBundle.java
+++ b/src/main/java/io/dropwizard/primer/PrimerBundle.java
@@ -44,6 +44,7 @@ import io.dropwizard.primer.model.PrimerBundleConfiguration;
 import io.dropwizard.primer.model.PrimerConfigurationHolder;
 import io.dropwizard.primer.model.PrimerRangerEndpoint;
 import io.dropwizard.primer.model.PrimerSimpleEndpoint;
+import io.dropwizard.primer.target.PrimerTarget;
 import io.dropwizard.server.DefaultServerFactory;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
@@ -139,7 +140,7 @@ public abstract class PrimerBundle<T extends Configuration> implements Configure
     environment.lifecycle().manage(new Managed() {
 
       @Override
-      public void start() {
+      public void start() throws Exception {
 
         // Create socket configuration
         SocketConfig socketConfig = SocketConfig.custom()
@@ -231,25 +232,14 @@ public abstract class PrimerBundle<T extends Configuration> implements Configure
         .build());
   }
 
-  private Target<PrimerClient> getPrimerTarget(T configuration, Environment environment) {
-    final val primerConfig = getPrimerConfiguration(configuration);
-    switch (primerConfig.getEndpoint().getType()) {
-      case "simple":
-        final val endpoint = (PrimerSimpleEndpoint) primerConfig.getEndpoint();
-        return new Target.HardCodedTarget<>(PrimerClient.class,
-            String.format("http://%s:%d", endpoint.getHost(), endpoint.getPort()));
-      case "ranger":
-        final val config = (PrimerRangerEndpoint) primerConfig.getEndpoint();
-        try {
-          return new RangerTarget<>(PrimerClient.class, config.getEnvironment(), config.getNamespace(),
-              config.getService(), getCurator(configuration), false, environment.getObjectMapper());
-        } catch (Exception e) {
-          log.error("Error creating ranger endpoint for primer", e);
-          return null;
-        }
-      default:
-        throw new IllegalArgumentException("unknown primer target type specified");
-    }
+  private Target<PrimerClient> getPrimerTarget(T configuration, Environment environment) throws Exception {
+    val primerConfig = getPrimerConfiguration(configuration);
+    return PrimerTarget.builder()
+            .primerEndpoint(primerConfig.getEndpoint())
+            .objectMapper(environment.getObjectMapper())
+            .curatorFrameworkSupplier(()->getCurator(configuration))
+            .build()
+            .getTarget();
   }
 
   public void initializeAuthorization(T configuration, ObjectMapper mapper) {

--- a/src/main/java/io/dropwizard/primer/model/PrimerEndpoint.java
+++ b/src/main/java/io/dropwizard/primer/model/PrimerEndpoint.java
@@ -17,12 +17,26 @@
 package io.dropwizard.primer.model;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 
 /**
  * @author phaneesh
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type", visible = true)
+@AllArgsConstructor
 public abstract class PrimerEndpoint {
 
     public abstract String getType();
+
+    @Getter
+    private final String rootPathPrefix;
+
+    @Getter
+    private final boolean secure;
+
+    protected PrimerEndpoint() {
+        rootPathPrefix = "";
+        secure = false;
+    }
 }

--- a/src/main/java/io/dropwizard/primer/model/PrimerRangerEndpoint.java
+++ b/src/main/java/io/dropwizard/primer/model/PrimerRangerEndpoint.java
@@ -22,19 +22,30 @@ import lombok.*;
  * @author phaneesh
  */
 @Data
-@AllArgsConstructor
-@NoArgsConstructor
-@Builder
 @EqualsAndHashCode(callSuper = true)
 public class PrimerRangerEndpoint extends PrimerEndpoint {
+    private final String type;
 
-    private String type;
+    private final String namespace;
 
-    private String namespace;
+    private final String zookeeper;
 
-    private String zookeeper;
+    private final String service;
 
-    private String service;
+    private final String environment;
 
-    private String environment;
+    //Backward compatibility for <=2.0.17
+    public PrimerRangerEndpoint(String type, String namespace, String zookeeper, String service, String environment) {
+        this(type, namespace, zookeeper, service, environment, "", false);
+    }
+
+    @Builder
+    public PrimerRangerEndpoint(String type, String namespace, String zookeeper, String service, String environment, String rootPathPrefix, boolean secure) {
+        super(rootPathPrefix, secure);
+        this.type = type;
+        this.namespace = namespace;
+        this.zookeeper = zookeeper;
+        this.service = service;
+        this.environment = environment;
+    }
 }

--- a/src/main/java/io/dropwizard/primer/model/PrimerSimpleEndpoint.java
+++ b/src/main/java/io/dropwizard/primer/model/PrimerSimpleEndpoint.java
@@ -16,22 +16,51 @@
 
 package io.dropwizard.primer.model;
 
-import lombok.*;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NonNull;
+
+import javax.annotation.Nonnegative;
 
 /**
  * @author phaneesh
  */
 @EqualsAndHashCode(callSuper = true)
 @Data
-@AllArgsConstructor
-@NoArgsConstructor
-@Builder
 public class PrimerSimpleEndpoint extends PrimerEndpoint {
 
-    private String type;
+    @NonNull
+    private final String type;
 
-    private String host;
+    @NonNull
+    private final String host;
 
-    private int port;
+    @Nonnegative
+    private final int port;
 
+    //Backward compatibility for <=2.0.17
+    public PrimerSimpleEndpoint(String type, String host, int port) {
+        this(type, host, port, "", false);
+    }
+
+    private int getDefaultPort() {
+        if (isSecure()) {
+            return 443;
+        } else {
+            return 80;
+        }
+    }
+
+    @Builder
+    public PrimerSimpleEndpoint(String type, String host, int port, String rootPathPrefix, boolean secure) {
+        super(rootPathPrefix, secure);
+        this.type = type;
+        this.host = host;
+        if (port == 0) {
+            this.port = getDefaultPort();
+        } else {
+            this.port = port;
+        }
+    }
 }

--- a/src/main/java/io/dropwizard/primer/target/PrimerTarget.java
+++ b/src/main/java/io/dropwizard/primer/target/PrimerTarget.java
@@ -1,0 +1,63 @@
+package io.dropwizard.primer.target;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import feign.Target;
+import feign.ranger.RangerTarget;
+import io.dropwizard.primer.client.PrimerClient;
+import io.dropwizard.primer.model.PrimerEndpoint;
+import io.dropwizard.primer.model.PrimerRangerEndpoint;
+import io.dropwizard.primer.model.PrimerSimpleEndpoint;
+import com.google.common.base.Strings;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.curator.framework.CuratorFramework;
+
+import java.util.function.Supplier;
+
+@Slf4j
+public class PrimerTarget {
+
+    @Getter
+    private final Target<PrimerClient> target;
+
+    @Builder
+    public PrimerTarget(PrimerEndpoint primerEndpoint, ObjectMapper objectMapper, Supplier<CuratorFramework> curatorFrameworkSupplier) throws Exception {
+        if (primerEndpoint instanceof PrimerSimpleEndpoint) {
+            this.target = makeTarget((PrimerSimpleEndpoint) primerEndpoint);
+        } else if (primerEndpoint instanceof PrimerRangerEndpoint) {
+            this.target = makeTarget((PrimerRangerEndpoint) primerEndpoint, objectMapper, curatorFrameworkSupplier.get());
+        } else {
+            throw new IllegalArgumentException("unknown primer target type specified");
+        }
+    }
+
+    private Target<PrimerClient> makeTarget(PrimerSimpleEndpoint primerSimpleEndpoint) {
+        String rootPathPrefix = "";
+        if (!Strings.isNullOrEmpty(primerSimpleEndpoint.getRootPathPrefix())) {
+            rootPathPrefix = "/" + primerSimpleEndpoint.getRootPathPrefix();
+        }
+
+        String httpScheme = "http";
+        if (primerSimpleEndpoint.isSecure()) {
+            httpScheme = "https";
+        }
+        String url = String.format("%s://%s:%d%s", httpScheme, primerSimpleEndpoint.getHost(), primerSimpleEndpoint.getPort(),
+                rootPathPrefix);
+        return new Target.HardCodedTarget<>(PrimerClient.class, url);
+    }
+
+    private Target<PrimerClient> makeTarget(PrimerRangerEndpoint primerRangerEndpoint,
+                                            ObjectMapper objectMapper,
+                                            CuratorFramework curatorFramework) throws Exception {
+        return RangerTarget.<PrimerClient>builder().type(PrimerClient.class)
+                .environment(primerRangerEndpoint.getEnvironment())
+                .namespace(primerRangerEndpoint.getNamespace())
+                .service(primerRangerEndpoint.getService())
+                .curator(curatorFramework)
+                .secured(primerRangerEndpoint.isSecure())
+                .objectMapper(objectMapper)
+                .rootPathPrefix(primerRangerEndpoint.getRootPathPrefix())
+                .build();
+    }
+}

--- a/src/test/java/io/dropwizard/primer/PrimerRangerTargetTest.java
+++ b/src/test/java/io/dropwizard/primer/PrimerRangerTargetTest.java
@@ -1,0 +1,125 @@
+package io.dropwizard.primer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.flipkart.ranger.ServiceProviderBuilders;
+import com.flipkart.ranger.healthcheck.Healthcheck;
+import com.flipkart.ranger.healthcheck.HealthcheckStatus;
+import com.flipkart.ranger.serviceprovider.ServiceProvider;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.google.common.collect.Lists;
+import feign.*;
+import feign.ranger.common.ShardInfo;
+import io.dropwizard.primer.client.PrimerClient;
+import io.dropwizard.primer.model.PrimerRangerEndpoint;
+import io.dropwizard.primer.target.PrimerTarget;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.retry.RetryForever;
+import org.apache.curator.test.TestingCluster;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.List;
+import static org.junit.Assert.*;
+
+@Slf4j
+public class PrimerRangerTargetTest {
+    private TestingCluster testingCluster;
+
+    private List<Healthcheck> healthchecks = Lists.newArrayList();
+    private ServiceProvider<ShardInfo> serviceProvider;
+
+    private CuratorFramework curator;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private final Logger.ErrorLogger logger = new Logger.ErrorLogger();
+
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule(9999);
+
+    @Before
+    public void startTestCluster() throws Exception {
+
+        testingCluster = new TestingCluster(1);
+        testingCluster.start();
+        curator = CuratorFrameworkFactory.builder()
+                .connectString(testingCluster.getConnectString())
+                .namespace("test")
+                .retryPolicy(new RetryForever(3000))
+                .build();
+        curator.start();
+        serviceProvider = ServiceProviderBuilders.<ShardInfo>shardedServiceProviderBuilder()
+                .withCuratorFramework(curator)
+                .withNamespace("test")
+                .withServiceName("test")
+                .withSerializer(data -> {
+                    try {
+                        return objectMapper.writeValueAsBytes(data);
+                    } catch (Exception e) {
+                        log.warn("Could not parse node data", e);
+                    }
+                    return null;
+                })
+                .withHostname("127.0.0.1")
+                .withPort(9999)
+                .withNodeData(ShardInfo.builder()
+                        .environment("test")
+                        .build())
+                .withHealthcheck(() -> {
+                    for(Healthcheck healthcheck : healthchecks) {
+                        if(HealthcheckStatus.unhealthy == healthcheck.check()) {
+                            return HealthcheckStatus.unhealthy;
+                        }
+                    }
+                    return HealthcheckStatus.healthy;
+                })
+                .buildServiceDiscovery();
+        serviceProvider.start();
+    }
+
+    @After
+    public void stopTestCluster() throws Exception {
+        if(null != serviceProvider ) {
+            serviceProvider.stop();
+        }
+        if(null != curator) {
+            curator.close();
+        }
+        if(null != testingCluster) {
+            testingCluster.close();
+        }
+
+    }
+
+    @Test
+    public void testHttpPrimerClient() throws Exception {
+        PrimerRangerEndpoint primerRangerEndpoint = PrimerRangerEndpoint.builder().type("ranger").environment("test").namespace("test").service("test").build();
+        Target<PrimerClient> primerClientTarget = PrimerTarget.builder().primerEndpoint(primerRangerEndpoint).objectMapper(objectMapper).curatorFrameworkSupplier(()->curator).build().getTarget();
+        assertEquals("http://127.0.0.1:9999", primerClientTarget.url());
+    }
+
+    @Test
+    public void testHttpsPrimerClient() throws Exception {
+        PrimerRangerEndpoint primerRangerEndpoint = PrimerRangerEndpoint.builder().type("ranger").environment("test").namespace("test").service("test").secure(true).build();
+        Target<PrimerClient> primerClientTarget = PrimerTarget.builder().primerEndpoint(primerRangerEndpoint).objectMapper(objectMapper).curatorFrameworkSupplier(()->curator).build().getTarget();
+        assertEquals("https://127.0.0.1:9999", primerClientTarget.url());
+    }
+
+    @Test
+    public void testHttpPrimerClientWithRootPathPrefix() throws Exception {
+        PrimerRangerEndpoint primerRangerEndpoint = PrimerRangerEndpoint.builder().type("ranger").environment("test").namespace("test").service("test").rootPathPrefix("apis/ks").build();
+        Target<PrimerClient> primerClientTarget = PrimerTarget.builder().primerEndpoint(primerRangerEndpoint).objectMapper(objectMapper).curatorFrameworkSupplier(()->curator).build().getTarget();
+        assertEquals("http://127.0.0.1:9999/apis/ks", primerClientTarget.url());
+    }
+
+    @Test
+    public void testHttpsPrimerClientWithRootPathPrefix() throws Exception {
+        PrimerRangerEndpoint primerRangerEndpoint = PrimerRangerEndpoint.builder().type("ranger").environment("test").namespace("test").service("test").secure(true).rootPathPrefix("apis/ks").build();
+        Target<PrimerClient> primerClientTarget = PrimerTarget.builder().primerEndpoint(primerRangerEndpoint).objectMapper(objectMapper).curatorFrameworkSupplier(()->curator).build().getTarget();
+        assertEquals("https://127.0.0.1:9999/apis/ks", primerClientTarget.url());
+    }
+}

--- a/src/test/java/io/dropwizard/primer/PrimerSimpleTargetTest.java
+++ b/src/test/java/io/dropwizard/primer/PrimerSimpleTargetTest.java
@@ -1,0 +1,53 @@
+package io.dropwizard.primer;
+
+import feign.Target;
+import io.dropwizard.primer.client.PrimerClient;
+import io.dropwizard.primer.model.PrimerSimpleEndpoint;
+import io.dropwizard.primer.target.PrimerTarget;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class PrimerSimpleTargetTest {
+
+    @Test
+    public void testSimpleClient() throws Exception {
+        PrimerSimpleEndpoint primerSimpleEndpoint = PrimerSimpleEndpoint.builder().host("127.0.0.1").port(80).type("simple").build();
+        Target<PrimerClient> primerClientTarget = PrimerTarget.builder().primerEndpoint(primerSimpleEndpoint).build().getTarget();
+        Assert.assertEquals("http://127.0.0.1:80", primerClientTarget.url());
+    }
+
+    @Test
+    public void testSimpleClientSecured() throws Exception {
+        PrimerSimpleEndpoint primerSimpleEndpoint = PrimerSimpleEndpoint.builder().host("127.0.0.1").type("simple").port(443).secure(true).build();
+        Target<PrimerClient> primerClientTarget = PrimerTarget.builder().primerEndpoint(primerSimpleEndpoint).build().getTarget();
+        Assert.assertEquals("https://127.0.0.1:443", primerClientTarget.url());
+    }
+
+    @Test
+    public void testSimpleClientDefaultPort() throws Exception {
+        PrimerSimpleEndpoint primerSimpleEndpoint = PrimerSimpleEndpoint.builder().host("127.0.0.1").type("simple").build();
+        Target<PrimerClient> primerClientTarget = PrimerTarget.builder().primerEndpoint(primerSimpleEndpoint).build().getTarget();
+        Assert.assertEquals("http://127.0.0.1:80", primerClientTarget.url());
+    }
+
+    @Test
+    public void testSimpleClientSecuredDefaultPort() throws Exception {
+        PrimerSimpleEndpoint primerSimpleEndpoint = PrimerSimpleEndpoint.builder().host("127.0.0.1").type("simple").secure(true).build();
+        Target<PrimerClient> primerClientTarget = PrimerTarget.builder().primerEndpoint(primerSimpleEndpoint).build().getTarget();
+        Assert.assertEquals("https://127.0.0.1:443", primerClientTarget.url());
+    }
+
+    @Test
+    public void testSimpleClientRootPathPrefix() throws Exception {
+        PrimerSimpleEndpoint primerSimpleEndpoint = PrimerSimpleEndpoint.builder().host("127.0.0.1").type("simple").rootPathPrefix("apis/ks").build();
+        Target<PrimerClient> primerClientTarget = PrimerTarget.builder().primerEndpoint(primerSimpleEndpoint).build().getTarget();
+        Assert.assertEquals("http://127.0.0.1:80/apis/ks", primerClientTarget.url());
+    }
+
+    @Test
+    public void testSimpleClientSecuredRootPathPrefix() throws Exception {
+        PrimerSimpleEndpoint primerSimpleEndpoint = PrimerSimpleEndpoint.builder().host("127.0.0.1").type("simple").secure(true).rootPathPrefix("apis/ks").build();
+        Target<PrimerClient> primerClientTarget = PrimerTarget.builder().primerEndpoint(primerSimpleEndpoint).build().getTarget();
+        Assert.assertEquals("https://127.0.0.1:443/apis/ks", primerClientTarget.url());
+    }
+}


### PR DESCRIPTION
When a call using primer client is done for `GET /v1/test`,
with the current implementation the call gets translated to:
`http://host:port/v1/test`

Some API gateways use a rootPathPrefix to decide which backend to send
a request. If we need to translate this call to a call accepted by gateway,
it should become:
`http://host:port/apis/backend/v1/test.`
where `apis/backend` is the `rootPathPrefix` to reach the backend

It would be better to have this capability in Primer Client.

Also added support for secure endpoints.

Signed-off-by: Pranith Kumar K <pranith.karampuri@phonepe.com>