### PR TITLE
Add Default Constructor for yaml decoding by jackson

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>io.raven.dropwizard</groupId>
     <artifactId>dropwizard-primer</artifactId>
-    <version>2.0.18</version>
+    <version>2.0.19</version>
     <packaging>jar</packaging>
 
     <name>dropwizard-primer</name>

--- a/src/main/java/io/dropwizard/primer/model/PrimerEndpoint.java
+++ b/src/main/java/io/dropwizard/primer/model/PrimerEndpoint.java
@@ -16,27 +16,27 @@
 
 package io.dropwizard.primer.model;
 
+import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 /**
  * @author phaneesh
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type", visible = true)
+@JsonSubTypes({@JsonSubTypes.Type(name = "simple", value = PrimerSimpleEndpoint.class),
+        @JsonSubTypes.Type(name = "ranger", value = PrimerRangerEndpoint.class)})
+@NoArgsConstructor
 @AllArgsConstructor
 public abstract class PrimerEndpoint {
 
     public abstract String getType();
 
     @Getter
-    private final String rootPathPrefix;
+    private String rootPathPrefix;
 
     @Getter
-    private final boolean secure;
-
-    protected PrimerEndpoint() {
-        rootPathPrefix = "";
-        secure = false;
-    }
+    private boolean secure;
 }

--- a/src/main/java/io/dropwizard/primer/model/PrimerRangerEndpoint.java
+++ b/src/main/java/io/dropwizard/primer/model/PrimerRangerEndpoint.java
@@ -22,17 +22,18 @@ import lombok.*;
  * @author phaneesh
  */
 @Data
+@NoArgsConstructor
 @EqualsAndHashCode(callSuper = true)
 public class PrimerRangerEndpoint extends PrimerEndpoint {
-    private final String type;
+    private String type;
 
-    private final String namespace;
+    private String namespace;
 
-    private final String zookeeper;
+    private String zookeeper;
 
-    private final String service;
+    private String service;
 
-    private final String environment;
+    private String environment;
 
     //Backward compatibility for <=2.0.17
     public PrimerRangerEndpoint(String type, String namespace, String zookeeper, String service, String environment) {
@@ -40,7 +41,7 @@ public class PrimerRangerEndpoint extends PrimerEndpoint {
     }
 
     @Builder
-    public PrimerRangerEndpoint(String type, String namespace, String zookeeper, String service, String environment, String rootPathPrefix, boolean secure) {
+    private PrimerRangerEndpoint(String type, String namespace, String zookeeper, String service, String environment, String rootPathPrefix, boolean secure) {
         super(rootPathPrefix, secure);
         this.type = type;
         this.namespace = namespace;

--- a/src/main/java/io/dropwizard/primer/model/PrimerSimpleEndpoint.java
+++ b/src/main/java/io/dropwizard/primer/model/PrimerSimpleEndpoint.java
@@ -16,10 +16,7 @@
 
 package io.dropwizard.primer.model;
 
-import lombok.Builder;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NonNull;
+import lombok.*;
 
 import javax.annotation.Nonnegative;
 
@@ -27,17 +24,18 @@ import javax.annotation.Nonnegative;
  * @author phaneesh
  */
 @EqualsAndHashCode(callSuper = true)
+@NoArgsConstructor
 @Data
+@Builder
 public class PrimerSimpleEndpoint extends PrimerEndpoint {
 
-    @NonNull
-    private final String type;
+    private String type;
 
     @NonNull
-    private final String host;
+    private String host;
 
     @Nonnegative
-    private final int port;
+    private int port;
 
     //Backward compatibility for <=2.0.17
     public PrimerSimpleEndpoint(String type, String host, int port) {
@@ -53,14 +51,18 @@ public class PrimerSimpleEndpoint extends PrimerEndpoint {
     }
 
     @Builder
-    public PrimerSimpleEndpoint(String type, String host, int port, String rootPathPrefix, boolean secure) {
+    private PrimerSimpleEndpoint(String type, String host, int port, String rootPathPrefix, boolean secure) {
         super(rootPathPrefix, secure);
         this.type = type;
         this.host = host;
+        this.port = port;
+    }
+
+    public int getPort() {
         if (port == 0) {
-            this.port = getDefaultPort();
+            return getDefaultPort();
         } else {
-            this.port = port;
+            return port;
         }
     }
 }

--- a/src/test/java/io/dropwizard/primer/ObjectMapperEndpointTest.java
+++ b/src/test/java/io/dropwizard/primer/ObjectMapperEndpointTest.java
@@ -1,0 +1,25 @@
+package io.dropwizard.primer;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.InvalidTypeIdException;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import io.dropwizard.primer.model.PrimerEndpoint;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ObjectMapperEndpointTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper(new YAMLFactory());
+
+    @Test(expected = InvalidTypeIdException.class)
+    public void testUnknownEndpoint() throws JsonProcessingException {
+        PrimerEndpoint primerEndpoint = objectMapper.readValue(
+                "---\n" +
+                        "type: unknown\n" +
+                        "namespace: test\n" +
+                        "service: test\n" +
+                        "rootPathPrefix: apis/primer", PrimerEndpoint.class);
+        Assert.fail("Parsing shouldn't have succeeded");
+    }
+}

--- a/src/test/java/io/dropwizard/primer/PrimerBundleTest.java
+++ b/src/test/java/io/dropwizard/primer/PrimerBundleTest.java
@@ -46,7 +46,7 @@ import static org.junit.Assert.fail;
 /**
  * @author phaneesh
  */
-public class PrimerBundleTests extends BaseTest {
+public class PrimerBundleTest extends BaseTest {
 
     @ClassRule
     public static ResourceTestRule resources = ResourceTestRule.builder()

--- a/src/test/java/io/dropwizard/primer/PrimerSimpleTargetTest.java
+++ b/src/test/java/io/dropwizard/primer/PrimerSimpleTargetTest.java
@@ -1,53 +1,56 @@
 package io.dropwizard.primer;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import feign.Target;
 import io.dropwizard.primer.client.PrimerClient;
-import io.dropwizard.primer.model.PrimerSimpleEndpoint;
+import io.dropwizard.primer.model.PrimerEndpoint;
 import io.dropwizard.primer.target.PrimerTarget;
 import org.junit.Assert;
 import org.junit.Test;
 
 public class PrimerSimpleTargetTest {
+    private final ObjectMapper objectMapper = new ObjectMapper(new YAMLFactory());
+
+    private void check(String extraConfig, String expectedUrl) throws Exception {
+        PrimerEndpoint primerEndpoint = objectMapper.readValue(
+                "---\n" +
+                        "type: simple\n" +
+                        "host: 127.0.0.1\n" +
+                        extraConfig, PrimerEndpoint.class);
+
+        Target<PrimerClient> primerClientTarget = PrimerTarget.builder().primerEndpoint(primerEndpoint).build().getTarget();
+        Assert.assertEquals(expectedUrl, primerClientTarget.url());
+    }
 
     @Test
     public void testSimpleClient() throws Exception {
-        PrimerSimpleEndpoint primerSimpleEndpoint = PrimerSimpleEndpoint.builder().host("127.0.0.1").port(80).type("simple").build();
-        Target<PrimerClient> primerClientTarget = PrimerTarget.builder().primerEndpoint(primerSimpleEndpoint).build().getTarget();
-        Assert.assertEquals("http://127.0.0.1:80", primerClientTarget.url());
+        check("port: 80", "http://127.0.0.1:80");
     }
 
     @Test
     public void testSimpleClientSecured() throws Exception {
-        PrimerSimpleEndpoint primerSimpleEndpoint = PrimerSimpleEndpoint.builder().host("127.0.0.1").type("simple").port(443).secure(true).build();
-        Target<PrimerClient> primerClientTarget = PrimerTarget.builder().primerEndpoint(primerSimpleEndpoint).build().getTarget();
-        Assert.assertEquals("https://127.0.0.1:443", primerClientTarget.url());
+        check("port: 443\n" + "secure: true", "https://127.0.0.1:443");
     }
 
     @Test
     public void testSimpleClientDefaultPort() throws Exception {
-        PrimerSimpleEndpoint primerSimpleEndpoint = PrimerSimpleEndpoint.builder().host("127.0.0.1").type("simple").build();
-        Target<PrimerClient> primerClientTarget = PrimerTarget.builder().primerEndpoint(primerSimpleEndpoint).build().getTarget();
-        Assert.assertEquals("http://127.0.0.1:80", primerClientTarget.url());
+        check("", "http://127.0.0.1:80");
     }
 
     @Test
     public void testSimpleClientSecuredDefaultPort() throws Exception {
-        PrimerSimpleEndpoint primerSimpleEndpoint = PrimerSimpleEndpoint.builder().host("127.0.0.1").type("simple").secure(true).build();
-        Target<PrimerClient> primerClientTarget = PrimerTarget.builder().primerEndpoint(primerSimpleEndpoint).build().getTarget();
-        Assert.assertEquals("https://127.0.0.1:443", primerClientTarget.url());
+        check("secure: true", "https://127.0.0.1:443");
     }
 
     @Test
     public void testSimpleClientRootPathPrefix() throws Exception {
-        PrimerSimpleEndpoint primerSimpleEndpoint = PrimerSimpleEndpoint.builder().host("127.0.0.1").type("simple").rootPathPrefix("apis/ks").build();
-        Target<PrimerClient> primerClientTarget = PrimerTarget.builder().primerEndpoint(primerSimpleEndpoint).build().getTarget();
-        Assert.assertEquals("http://127.0.0.1:80/apis/ks", primerClientTarget.url());
+        check("rootPathPrefix: apis/ks", "http://127.0.0.1:80/apis/ks");
     }
 
     @Test
     public void testSimpleClientSecuredRootPathPrefix() throws Exception {
-        PrimerSimpleEndpoint primerSimpleEndpoint = PrimerSimpleEndpoint.builder().host("127.0.0.1").type("simple").secure(true).rootPathPrefix("apis/ks").build();
-        Target<PrimerClient> primerClientTarget = PrimerTarget.builder().primerEndpoint(primerSimpleEndpoint).build().getTarget();
-        Assert.assertEquals("https://127.0.0.1:443/apis/ks", primerClientTarget.url());
+        check("secure: true\n" + "rootPathPrefix: apis/ks", "https://127.0.0.1:443/apis/ks");
     }
 }


### PR DESCRIPTION
In 2.0.18 Default constructor is removed by mistake which is affecting
jackson decoding to create the PrimerEndpoint. Added them back and added
tests to prevent such errors in future.

Renamed PrimerBundleTests -> PrimerBundleTest to make sure mvn test runs
the tests in that class.

Signed-off-by: Pranith Kumar K <pranith.karampuri@phonepe.com>